### PR TITLE
Set device of start class token in autoregressive log_prob

### DIFF
--- a/torch_struct/autoregressive.py
+++ b/torch_struct/autoregressive.py
@@ -88,8 +88,8 @@ class Autoregressive(Distribution):
         value = torch.cat(
             [
                 torch.zeros(sample, batch_shape, 1, device=value.device)
-                    .fill_(self.start_class)
-                    .long(),
+                     .fill_(self.start_class)
+                     .long(),
                 value,
             ],
             dim=2,

--- a/torch_struct/autoregressive.py
+++ b/torch_struct/autoregressive.py
@@ -86,7 +86,12 @@ class Autoregressive(Distribution):
             sample, batch_shape, n_length = value.shape
 
         value = torch.cat(
-            [torch.zeros(sample, batch_shape, 1).fill_(self.start_class).long(), value],
+            [
+                torch.zeros(sample, batch_shape, 1, device=value.device)
+                    .fill_(self.start_class)
+                    .long(),
+                value,
+            ],
             dim=2,
         )
         value = unwrap(value)


### PR DESCRIPTION
There was a device mismatch when using Autoregressive.log_prob on gpu, the start_class tensor was constructed on the default device.