### PR TITLE
fix inconsistent interface implementation

### DIFF
--- a/torch_struct/cky.py
+++ b/torch_struct/cky.py
@@ -78,7 +78,7 @@ class CKY(_Struct):
         log_Z = semiring.dot(top, roots)
         return semiring.unconvert(log_Z), (term_use, rules, top, span[1:]), beta
 
-    def marginals(self, scores, lengths=None, _autograd=True):
+    def marginals(self, scores, lengths=None, _autograd=True, _raw=False):
         """
         Compute the marginals of a CFG using CKY.
 
@@ -92,6 +92,8 @@ class CKY(_Struct):
             spans: bxNxT terms, (bxNTx(NT+S)x(NT+S)) rules, bxNT roots
 
         """
+        assert not _raw, "top k > 1 with CKY is not supported."
+
         terms, rules, roots = scores
         batch, N, T = terms.shape
         _, NT, _, _ = rules.shape

--- a/torch_struct/cky.py
+++ b/torch_struct/cky.py
@@ -76,7 +76,7 @@ class CKY(_Struct):
         final = beta[A][0, :, NTs]
         top = torch.stack([final[:, i, l - 1] for i, l in enumerate(lengths)], dim=1)
         log_Z = semiring.dot(top, roots)
-        return semiring.unconvert(log_Z), (term_use, rules, top, span[1:]), beta
+        return log_Z, (term_use, rules, roots, span[1:]), beta
 
     def marginals(self, scores, lengths=None, _autograd=True, _raw=False):
         """
@@ -92,39 +92,49 @@ class CKY(_Struct):
             spans: bxNxT terms, (bxNTx(NT+S)x(NT+S)) rules, bxNT roots
 
         """
-        assert not _raw, "top k > 1 with CKY is not supported."
-
         terms, rules, roots = scores
         batch, N, T = terms.shape
         _, NT, _, _ = rules.shape
-        v, (term_use, rule_use, top, spans), alpha = self._dp(
+
+        v, (term_use, rule_use, root_use, spans), alpha = self._dp(
             scores, lengths=lengths, force_grad=True
         )
+        inputs = (rule_use, root_use, term_use) + tuple(spans)
 
-        marg = torch.autograd.grad(
-            v.sum(dim=0),
-            (rule_use, top, term_use) + tuple(spans),
-            create_graph=True,
-            only_inputs=True,
-            allow_unused=False,
-        )
-
-        spans_marg = torch.zeros(
-            batch, N, N, NT, dtype=scores[1].dtype, device=scores[1].device
-        )
-        span_ls = marg[3:]
-        for w in range(len(span_ls)):
-            spans_marg[:, w, : N - w - 1] = self.semiring.unconvert(
-                span_ls[w].squeeze(1)
+        def marginal(obj, inputs):
+            obj = self.semiring.unconvert(v).sum(dim=0)
+            marg = torch.autograd.grad(
+                obj, inputs, create_graph=True, only_inputs=True, allow_unused=False,
             )
-        rule_use = self.semiring.unconvert(marg[0]).squeeze(1)
-        term_marg = self.semiring.unconvert(marg[2])
-        root_marg = self.semiring.unconvert(marg[1])
 
-        assert term_marg.shape == (batch, N, T)
-        assert root_marg.shape == (batch, NT)
-        assert rule_use.shape == (batch, NT, NT + T, NT + T)
-        return (term_marg, rule_use, root_marg, spans_marg)
+            spans_marg = torch.zeros(
+                batch, N, N, NT, dtype=scores[1].dtype, device=scores[1].device
+            )
+            span_ls = marg[3:]
+            for w in range(len(span_ls)):
+                spans_marg[:, w, : N - w - 1] = self.semiring.unconvert(span_ls[w])
+
+            rule_marg = self.semiring.unconvert(marg[0]).squeeze(1)
+            root_marg = self.semiring.unconvert(marg[1])
+            term_marg = self.semiring.unconvert(marg[2])
+
+            assert term_marg.shape == (batch, N, T)
+            assert root_marg.shape == (batch, NT)
+            assert rule_marg.shape == (batch, NT, NT + T, NT + T)
+            return (term_marg, rule_marg, root_marg, spans_marg)
+
+        if _raw:
+            paths = []
+            for k in range(v.shape[0]):
+                obj = v[k : k + 1]
+                marg = marginal(obj, inputs)
+                paths.append(marg[-1])
+            paths = torch.stack(paths, 0)
+            obj = v.sum(dim=0, keepdim=True)
+            term_marg, rule_marg, root_marg, _ = marginal(obj, inputs)
+            return term_marg, rule_marg, root_marg, paths
+        else:
+            return marginal(v, inputs)
 
     def score(self, potentials, parts):
         terms, rules, roots = potentials[:3]


### PR DESCRIPTION
The interface implementation in 
https://github.com/harvardnlp/pytorch-struct/blob/f9f2530c73fa6a399e90bc9996ab406f5b4d9a03/torch_struct/cky.py#L73
Is inconsistent with its declaration in 
https://github.com/harvardnlp/pytorch-struct/blob/876588d9a75a21a4a1a5c77d3110f21dcfd836e7/torch_struct/helpers.py#L139
resulting in an error when invoking `topk()`
https://github.com/harvardnlp/pytorch-struct/blob/876588d9a75a21a4a1a5c77d3110f21dcfd836e7/torch_struct/distributions.py#L96-L98
This pr will raise an error when invoking unsupported `topk()` with `CKY`.