### PR TITLE
multi-root non-projective dependency crf with lengths mask

### DIFF
--- a/torch_struct/deptree.py
+++ b/torch_struct/deptree.py
@@ -203,9 +203,9 @@ class DepTree(_Struct):
 def deptree_part(arc_scores, multi_root, lengths, eps=1e-5):
     if lengths:
         batch, N, N = arc_scores.shape
-        x = torch.arange(N).expand(batch, N)
+        x = torch.arange(N, device=arc_scores.device).expand(batch, N)
         if not torch.is_tensor(lengths):
-            lengths = torch.tensor(lengths)
+            lengths = torch.tensor(lengths, device=arc_scores.device)
         lengths = lengths.unsqueeze(1)
         x = x < lengths
         x = x.unsqueeze(2).expand(-1, -1, N)
@@ -247,9 +247,9 @@ def deptree_nonproj(arc_scores, multi_root, lengths, eps=1e-5):
     """
     if lengths is not None:
         batch, N, N = arc_scores.shape
-        x = torch.arange(N).expand(batch, N)
+        x = torch.arange(N, device=arc_scores.device).expand(batch, N)
         if not torch.is_tensor(lengths):
-            lengths = torch.tensor(lengths)
+            lengths = torch.tensor(lengths, device=arc_scores.device)
         lengths = lengths.unsqueeze(1)
         x = x < lengths
         x = x.unsqueeze(2).expand(-1, -1, N)

--- a/torch_struct/deptree.py
+++ b/torch_struct/deptree.py
@@ -220,7 +220,8 @@ def deptree_part(arc_scores, multi_root, lengths, eps=1e-5):
     laplacian = input.exp() + eps
     lap = laplacian.masked_fill(eye != 0, 0)
     lap = -lap + torch.diag_embed(lap.sum(1), offset=0, dim1=-2, dim2=-1)
-    lap += det_offset
+    if lengths is not None:
+        lap += det_offset
 
     if multi_root:
         rss = torch.diagonal(input, 0, -2, -1).exp() # root selection scores
@@ -266,7 +267,8 @@ def deptree_nonproj(arc_scores, multi_root, lengths, eps=1e-5):
     laplacian = input.exp() + eps
     lap = laplacian.masked_fill(eye != 0, 0)
     lap = -lap + torch.diag_embed(lap.sum(1), offset=0, dim1=-2, dim2=-1)
-    lap += det_offset
+    if lengths is not None:
+        lap += det_offset
 
     if multi_root:
         rss = torch.diagonal(input, 0, -2, -1).exp() # root selection scores

--- a/torch_struct/deptree.py
+++ b/torch_struct/deptree.py
@@ -202,20 +202,12 @@ class DepTree(_Struct):
 
 def deptree_part(arc_scores, multi_root, eps=1e-5):
     input = arc_scores
-    '''
-    if multi_root:
-        rss = torch.diagonal(input, 0, -2, -1) # root selection scores
-        input = torch.cat((rss.unsqueeze(1), input), dim=1) # expand row-wise
-        rss = torch.cat((torch.ones(rss.shape[0], 1), rss), dim=1) # add a dummy 1, will be masked
-        input = torch.cat((rss.unsqueeze(2), input), dim=2)  # expand col-wise
-    '''
     eye = torch.eye(input.shape[1], device=input.device)
     laplacian = input.exp() + eps
     lap = laplacian.masked_fill(eye != 0, 0)
     lap = -lap + torch.diag_embed(lap.sum(1), offset=0, dim1=-2, dim2=-1)
     
     if multi_root:
-        #lap = lap[:,1:,:][:,:,1:] # minor of lap
         rss = torch.diagonal(input, 0, -2, -1).exp() # root selection scores
         lap = lap + torch.diag_embed(rss, offset=0, dim1=-2, dim2=-1)
     else:
@@ -240,16 +232,6 @@ def deptree_nonproj(arc_scores, multi_root, eps=1e-5):
     Returns:
          arc_marginals : b x N x N.
     """
-
-    # use autograd to compute marginals
-    '''
-    arc_scores = arc_scores.double()
-    partition = deptree_part(arc_scores, multi_root)
-    import torch.autograd as autograd
-    probs, = autograd.grad(partition, arc_scores, torch.ones_like(partition))
-    return probs.float()
-    '''
-
     input = arc_scores
     eye = torch.eye(input.shape[1], device=input.device)
     laplacian = input.exp() + eps
@@ -289,10 +271,6 @@ def deptree_nonproj(arc_scores, multi_root, eps=1e-5):
             torch.diagonal(input, 0, -2, -1).exp().mul(inv_laplacian.transpose(1, 2)[:, 0])
         )
     output = output + torch.diag_embed(roots_output, 0, -2, -1)
-    #print (output)
-    #print (probs)
-    #print (torch.all(torch.eq(output.float(), probs.float())))
-    
     return output
 
 

--- a/torch_struct/deptree.py
+++ b/torch_struct/deptree.py
@@ -204,8 +204,10 @@ def deptree_part(arc_scores, multi_root, lengths, eps=1e-5):
     if lengths:
         batch, N, N = arc_scores.shape
         x = torch.arange(N).expand(batch, N)
-        length = torch.tensor(lengths).unsqueeze(1)
-        x = x < length
+        if not torch.is_tensor(lengths):
+            lengths = torch.tensor(lengths)
+        lengths = lengths.unsqueeze(1)
+        x = x < lengths
         x = x.unsqueeze(2).expand(-1, -1, N)
         mask = torch.transpose(x, 1, 2) * x
         mask = mask.float()
@@ -243,11 +245,13 @@ def deptree_nonproj(arc_scores, multi_root, lengths, eps=1e-5):
     Returns:
          arc_marginals : b x N x N.
     """
-    if lengths:
+    if lengths is not None:
         batch, N, N = arc_scores.shape
         x = torch.arange(N).expand(batch, N)
-        length = torch.tensor(lengths).unsqueeze(1)
-        x = x < length
+        if not torch.is_tensor(lengths):
+            lengths = torch.tensor(lengths)
+        lengths = lengths.unsqueeze(1)
+        x = x < lengths
         x = x.unsqueeze(2).expand(-1, -1, N)
         mask = torch.transpose(x, 1, 2) * x
         mask = mask.float()

--- a/torch_struct/distributions.py
+++ b/torch_struct/distributions.py
@@ -476,7 +476,7 @@ class NonProjectiveDependencyCRF(StructDistribution):
         Returns:
             marginals (*batch_shape x event_shape*)
         """
-        return deptree_nonproj(self.log_potentials, self.multiroot)
+        return deptree_nonproj(self.log_potentials, self.multiroot, self.lengths)
 
     def sample(self, sample_shape=torch.Size()):
         raise NotImplementedError()
@@ -486,7 +486,7 @@ class NonProjectiveDependencyCRF(StructDistribution):
         """
         Compute the partition function.
         """
-        return deptree_part(self.log_potentials, self.multiroot)
+        return deptree_part(self.log_potentials, self.multiroot, self.lengths)
 
     @lazy_property
     def argmax(self):

--- a/torch_struct/distributions.py
+++ b/torch_struct/distributions.py
@@ -461,8 +461,10 @@ class NonProjectiveDependencyCRF(StructDistribution):
     Note: Does not currently implement argmax (Chiu-Liu) or sampling.
 
     """
-
-    struct = DepTree
+    def __init__(self, log_potentials, lengths=None, args={}, multiroot=False):
+        super(NonProjectiveDependencyCRF, self).__init__(log_potentials, lengths, args)
+        self.multiroot = multiroot
+        
 
     @lazy_property
     def marginals(self):
@@ -474,7 +476,7 @@ class NonProjectiveDependencyCRF(StructDistribution):
         Returns:
             marginals (*batch_shape x event_shape*)
         """
-        return deptree_nonproj(self.log_potentials)
+        return deptree_nonproj(self.log_potentials, self.multiroot)
 
     def sample(self, sample_shape=torch.Size()):
         raise NotImplementedError()
@@ -484,7 +486,7 @@ class NonProjectiveDependencyCRF(StructDistribution):
         """
         Compute the partition function.
         """
-        return deptree_part(self.log_potentials)
+        return deptree_part(self.log_potentials, self.multiroot)
 
     @lazy_property
     def argmax(self):


### PR DESCRIPTION
Hi,

I implement the feature as stated in title. The implementation basically follows section 3.3 of [1] with similar gradient update rules for marginals (like those in 3.2). I check marginals using the log-partition/marginals identity and they are the same. Let me know if anything needs to be improved!

[1] Structured Prediction Models via the Matrix-Tree Theorem. Koo et al. 2007.