### PR TITLE
Remove imperative filling functions _ 

### DIFF
--- a/tests/extensions.py
+++ b/tests/extensions.py
@@ -26,7 +26,17 @@ class LinearChainTest:
         semiring = semiring
         ssize = semiring.size()
         edge, batch, N, C, lengths = model._check_potentials(edge, lengths)
-        chains = [[([c], semiring.one_(torch.zeros(ssize, batch))) for c in range(C)]]
+        chains = [
+            [
+                (
+                    [c],
+                    semiring.fill(
+                        torch.zeros(ssize, batch), torch.tensor(True), semiring.one
+                    ),
+                )
+                for c in range(C)
+            ]
+        ]
 
         enum_lengths = torch.LongTensor(lengths.shape)
         for n in range(1, N):
@@ -128,7 +138,13 @@ class SemiMarkovTest:
         edge = semiring.convert(edge)
         chains = {}
         chains[0] = [
-            ([(c, 0)], semiring.one_(torch.zeros(ssize, batch))) for c in range(C)
+            (
+                [(c, 0)],
+                semiring.fill(
+                    torch.zeros(ssize, batch), torch.tensor(True), semiring.one
+                ),
+            )
+            for c in range(C)
         ]
 
         for n in range(1, N + 1):

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -263,7 +263,7 @@ def test_generic_lengths(model_test, data):
     part = model().sum(vals, lengths=lengths)
 
     # Check that max is correct
-    assert (maxes <= part).all()
+    assert (maxes <= part + 1e-3).all()
     m_part = model(MaxSemiring).sum(vals, lengths=lengths)
     assert (torch.isclose(maxes, m_part)).all(), maxes - m_part
 

--- a/torch_struct/autoregressive.py
+++ b/torch_struct/autoregressive.py
@@ -118,8 +118,10 @@ class Autoregressive(Distribution):
         return wrap(scores, sample)
 
     def _beam_search(self, semiring, gumbel=False):
-        beam = semiring.one_(
-            torch.zeros((semiring.size(),) + self.batch_shape, device=self.device)
+        beam = semiring.fill(
+            torch.zeros((semiring.size(),) + self.batch_shape, device=self.device),
+            torch.tensor(True),
+            semiring.one,
         )
         ssize = semiring.size()
 

--- a/torch_struct/distributions.py
+++ b/torch_struct/distributions.py
@@ -36,6 +36,7 @@ class StructDistribution(Distribution):
         log_potentials (tensor, batch_shape x event_shape) :  log-potentials :math:`\phi`
         lengths (long tensor, batch_shape) : integers for length masking
     """
+    validate_args = False
 
     def __init__(self, log_potentials, lengths=None, args={}):
         batch_shape = log_potentials.shape[:1]

--- a/torch_struct/linearchain.py
+++ b/torch_struct/linearchain.py
@@ -53,7 +53,9 @@ class LinearChain(_Struct):
         chart = self._chart((batch, bin_N, C, C), log_potentials, force_grad)
 
         # Init
-        semiring.one_(chart[:, :, :].diagonal(0, 3, 4))
+        init = torch.zeros(*chart.shape).bool()
+        init.diagonal(0, 3, 4).fill_(True)
+        chart = semiring.fill(chart, init, semiring.one)
 
         # Length mask
         big = torch.zeros(
@@ -71,10 +73,10 @@ class LinearChain(_Struct):
         mask = torch.arange(bin_N).view(1, bin_N).expand(batch, bin_N).type_as(c)
         mask = mask >= (lengths - 1).view(batch, 1)
         mask = mask.view(batch * bin_N, 1, 1).to(lp.device)
-        semiring.zero_mask_(lp.data, mask)
-        semiring.zero_mask_(c.data, (~mask))
+        lp.data = semiring.fill(lp, mask, semiring.zero)
+        m = semiring.fill(c.data, ~mask, semiring.zero)
 
-        c[:] = semiring.sum(torch.stack([c.data, lp], dim=-1))
+        c[:] = semiring.sum(torch.stack([m, lp], dim=-1))
 
         # Scan
         for n in range(1, log_N + 1):

--- a/torch_struct/linearchain.py
+++ b/torch_struct/linearchain.py
@@ -73,10 +73,10 @@ class LinearChain(_Struct):
         mask = torch.arange(bin_N).view(1, bin_N).expand(batch, bin_N).type_as(c)
         mask = mask >= (lengths - 1).view(batch, 1)
         mask = mask.view(batch * bin_N, 1, 1).to(lp.device)
-        lp.data = semiring.fill(lp, mask, semiring.zero)
-        m = semiring.fill(c.data, ~mask, semiring.zero)
+        lp.data[:] = semiring.fill(lp.data, mask, semiring.zero)
+        c.data[:] = semiring.fill(c.data, ~mask, semiring.zero)
 
-        c[:] = semiring.sum(torch.stack([m, lp], dim=-1))
+        c[:] = semiring.sum(torch.stack([c.data, lp], dim=-1))
 
         # Scan
         for n in range(1, log_N + 1):

--- a/torch_struct/semimarkov.py
+++ b/torch_struct/semimarkov.py
@@ -56,10 +56,10 @@ class SemiMarkov(_Struct):
         mask = mask.to(log_potentials.device)
         mask = mask >= (lengths - 1).view(batch, 1)
         mask = mask.view(batch * bin_N, 1, 1, 1).to(lp.device)
-        lp.data = semiring.fill(lp.data, mask, semiring.zero)
-        m = semiring.fill(c.data[:, :, :, 0], (~mask), semiring.zero)
+        lp.data[:] = semiring.fill(lp.data, mask, semiring.zero)
+        c.data[:, :, :, 0] = semiring.fill(c.data[:, :, :, 0], (~mask), semiring.zero)
         c[:, :, : K - 1, 0] = semiring.sum(
-            torch.stack([m.data[:, :, : K - 1], lp[:, :, 1:K]], dim=-1)
+            torch.stack([c.data[:, :, : K - 1, 0], lp[:, :, 1:K]], dim=-1)
         )
         end = torch.min(lengths) - 1
         mask = torch.zeros(*init.shape).bool()

--- a/torch_struct/semirings/checkpoint.py
+++ b/torch_struct/semirings/checkpoint.py
@@ -4,6 +4,7 @@ has_genbmm = False
 try:
     import genbmm
     from genbmm import BandedMatrix
+
     has_genbmm = True
 except ImportError:
     pass

--- a/torch_struct/semirings/semirings.py
+++ b/torch_struct/semirings/semirings.py
@@ -252,7 +252,8 @@ class KLDivergenceSemiring(Semiring):
 
     """
 
-    zero = torch.tensor(0.0)
+    zero = torch.tensor([-1e5, -1e5, 0.0])
+    one = torch.tensor([0.0, 0.0, 0.0])
 
     @staticmethod
     def size():

--- a/torch_struct/semirings/semirings.py
+++ b/torch_struct/semirings/semirings.py
@@ -47,6 +47,11 @@ class Semiring:
         b = b.unsqueeze(-1)
         return cls.matmul(a, b).squeeze(-1).squeeze(-1)
 
+    def fill(c, mask, v):
+        return torch.where(
+            mask, v.type_as(c).view((-1,) + (1,) * (len(c.shape) - 1)), c
+        )
+
     @classmethod
     def times(cls, *ls):
         "Multiply a list of tensors together"
@@ -66,21 +71,6 @@ class Semiring:
         return potentials.squeeze(0)
 
     @staticmethod
-    def zero_(xs):
-        "Fill *ssize x ...* tensor with additive identity."
-        raise NotImplementedError()
-
-    @classmethod
-    def zero_mask_(cls, xs, mask):
-        "Fill *ssize x ...* tensor with additive identity."
-        xs.masked_fill_(mask.unsqueeze(0), cls.zero)
-
-    @staticmethod
-    def one_(xs):
-        "Fill *ssize x ...* tensor with multiplicative identity."
-        raise NotImplementedError()
-
-    @staticmethod
     def sum(xs, dim=-1):
         "Sum over *dim* of tensor."
         raise NotImplementedError()
@@ -91,7 +81,8 @@ class Semiring:
 
 
 class _Base(Semiring):
-    zero = 0
+    zero = torch.tensor(0.0)
+    one = torch.tensor(1.0)
 
     @staticmethod
     def mul(a, b):
@@ -101,17 +92,10 @@ class _Base(Semiring):
     def prod(a, dim=-1):
         return torch.prod(a, dim=dim)
 
-    @staticmethod
-    def zero_(xs):
-        return xs.fill_(0)
-
-    @staticmethod
-    def one_(xs):
-        return xs.fill_(1)
-
 
 class _BaseLog(Semiring):
-    zero = -1e9
+    zero = torch.tensor(-1e5)
+    one = torch.tensor(-0.0)
 
     @staticmethod
     def sum(xs, dim=-1):
@@ -120,14 +104,6 @@ class _BaseLog(Semiring):
     @staticmethod
     def mul(a, b):
         return a + b
-
-    @staticmethod
-    def zero_(xs):
-        return xs.fill_(-1e5)
-
-    @staticmethod
-    def one_(xs):
-        return xs.fill_(0.0)
 
     @staticmethod
     def prod(a, dim=-1):
@@ -200,6 +176,10 @@ def KMaxSemiring(k):
     "Implements the k-max semiring (kmax, +, [-inf, -inf..], [0, -inf, ...])."
 
     class KMaxSemiring(_BaseLog):
+
+        zero = torch.tensor([-1e5 for i in range(k)])
+        one = torch.tensor([0 if i == 0 else -1e5 for i in range(k)])
+
         @staticmethod
         def size():
             return k
@@ -211,15 +191,9 @@ def KMaxSemiring(k):
                 dtype=orig_potentials.dtype,
                 device=orig_potentials.device,
             )
-            cls.zero_(potentials)
+            potentials = cls.fill(potentials, torch.tensor(True), cls.zero)
             potentials[0] = orig_potentials
             return potentials
-
-        @classmethod
-        def one_(cls, xs):
-            cls.zero_(xs)
-            xs[0].fill_(0)
-            return xs
 
         @staticmethod
         def unconvert(potentials):
@@ -277,7 +251,7 @@ class KLDivergenceSemiring(Semiring):
 
     """
 
-    zero = 0
+    zero = torch.tensor(0.0)
 
     @staticmethod
     def size():
@@ -322,27 +296,6 @@ class KLDivergenceSemiring(Semiring):
     def prod(cls, xs, dim=-1):
         return xs.sum(dim)
 
-    @classmethod
-    def zero_mask_(cls, xs, mask):
-        "Fill *ssize x ...* tensor with additive identity."
-        xs[0].masked_fill_(mask, -1e5)
-        xs[1].masked_fill_(mask, -1e5)
-        xs[2].masked_fill_(mask, 0)
-
-    @staticmethod
-    def zero_(xs):
-        xs[0].fill_(-1e5)
-        xs[1].fill_(-1e5)
-        xs[2].fill_(0)
-        return xs
-
-    @staticmethod
-    def one_(xs):
-        xs[0].fill_(0)
-        xs[1].fill_(0)
-        xs[2].fill_(0)
-        return xs
-
 
 class CrossEntropySemiring(Semiring):
     """
@@ -357,7 +310,8 @@ class CrossEntropySemiring(Semiring):
     * Sample Selection for Statistical Grammar Induction :cite:`hwa2000samplesf`
     """
 
-    zero = 0
+    zero = torch.tensor([-1e5, -1e5, 0.0])
+    one = torch.tensor([0.0, 0.0, 0.0])
 
     @staticmethod
     def size():
@@ -396,27 +350,6 @@ class CrossEntropySemiring(Semiring):
     def prod(cls, xs, dim=-1):
         return xs.sum(dim)
 
-    @classmethod
-    def zero_mask_(cls, xs, mask):
-        "Fill *ssize x ...* tensor with additive identity."
-        xs[0].masked_fill_(mask, -1e5)
-        xs[1].masked_fill_(mask, -1e5)
-        xs[2].masked_fill_(mask, 0)
-
-    @staticmethod
-    def zero_(xs):
-        xs[0].fill_(-1e5)
-        xs[1].fill_(-1e5)
-        xs[2].fill_(0)
-        return xs
-
-    @staticmethod
-    def one_(xs):
-        xs[0].fill_(0)
-        xs[1].fill_(0)
-        xs[2].fill_(0)
-        return xs
-
 
 class EntropySemiring(Semiring):
     """
@@ -431,7 +364,8 @@ class EntropySemiring(Semiring):
     * Sample Selection for Statistical Grammar Induction :cite:`hwa2000samplesf`
     """
 
-    zero = 0
+    zero = torch.tensor([-1e5, 0.0])
+    one = torch.tensor([0.0, 0.0])
 
     @staticmethod
     def size():
@@ -464,24 +398,6 @@ class EntropySemiring(Semiring):
     @classmethod
     def prod(cls, xs, dim=-1):
         return xs.sum(dim)
-
-    @classmethod
-    def zero_mask_(cls, xs, mask):
-        "Fill *ssize x ...* tensor with additive identity."
-        xs[0].masked_fill_(mask, -1e5)
-        xs[1].masked_fill_(mask, 0)
-
-    @staticmethod
-    def zero_(xs):
-        xs[0].fill_(-1e5)
-        xs[1].fill_(0)
-        return xs
-
-    @staticmethod
-    def one_(xs):
-        xs[0].fill_(0)
-        xs[1].fill_(0)
-        return xs
 
 
 def TempMax(alpha):

--- a/torch_struct/semirings/semirings.py
+++ b/torch_struct/semirings/semirings.py
@@ -47,6 +47,7 @@ class Semiring:
         b = b.unsqueeze(-1)
         return cls.matmul(a, b).squeeze(-1).squeeze(-1)
 
+    @staticmethod
     def fill(c, mask, v):
         return torch.where(
             mask, v.type_as(c).view((-1,) + (1,) * (len(c.shape) - 1)), c


### PR DESCRIPTION
This PR moves from the modifying tensors inline to instead using torch.where to create new ones. 

This has a couple of advantages namely : 

* fixing the broken build code 
* removing lots of repeated semiring logic
* unifying this with much of the jax code. 