### PR TITLE
Add alignment CRF test. Fix missing fill_()

### DIFF
--- a/tests/test_alignment_crf.py
+++ b/tests/test_alignment_crf.py
@@ -3,8 +3,8 @@ import torch_struct
 import warnings
 
 
-def test_alignment_crf():
-    batch, N, M = 1, 4, 5
+def test_alignment_crf_shapes():
+    batch, N, M = 2, 4, 5
     log_potentials = torch.rand(batch, N, M, 3)
 
     if torch.cuda.is_available():
@@ -14,6 +14,17 @@ def test_alignment_crf():
                       'Will not test marginals.')
 
     dist = torch_struct.AlignmentCRF(log_potentials)
-    assert (N, M, 3) == dist.argmax[0].shape
+    assert (batch, N, M, 3) == dist.argmax.shape
     if torch.cuda.is_available():
-        assert (N, M, 3) == dist.marginals[0].shape
+        assert (batch, N, M, 3) == dist.marginals.shape
+        assert (batch,) == dist.partition.shape
+
+        # Fail due to AttributeError: 'BandedMatrix' object has no attribute
+        # 'unsqueeze'
+        # assert (batch,) == dist.entropy.shape
+        # assert (9, batch, N, M, 3) == dist.sample([9]).shape
+
+        # Fails due to: RuntimeError: Expected condition, x and y to be on
+        # the same device, but condition is on cpu and x and y are on
+        # cuda:0 and cuda:0 respectively
+        # assert (8, batch,) == dist.topk(8).shape

--- a/tests/test_alignment_crf.py
+++ b/tests/test_alignment_crf.py
@@ -11,7 +11,7 @@ def test_alignment_crf():
         log_potentials = log_potentials.cuda()
         on_cuda = True
 
-    except Exception:
+    except RuntimeError:
         warnings.warn('Could not move log potentials to CUDA device. '
                       'Will not test marginals.')
         on_cuda = False

--- a/tests/test_alignment_crf.py
+++ b/tests/test_alignment_crf.py
@@ -1,10 +1,9 @@
 import torch
 import torch_struct
-import warnings
 import pytest
 
 
-@pytest.skipif(not torch.cuda.isavailable(), 'needs CUDA')
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='needs CUDA')
 def test_alignment_crf_shapes():
     batch, N, M = 2, 4, 5
     log_potentials = torch.rand(batch, N, M, 3).cuda()

--- a/tests/test_alignment_crf.py
+++ b/tests/test_alignment_crf.py
@@ -7,16 +7,13 @@ def test_alignment_crf():
     batch, N, M = 1, 4, 5
     log_potentials = torch.rand(batch, N, M, 3).cuda()
 
-    try:
+    if torch.cuda.is_available():
         log_potentials = log_potentials.cuda()
-        on_cuda = True
-
-    except RuntimeError:
+    else:
         warnings.warn('Could not move log potentials to CUDA device. '
                       'Will not test marginals.')
-        on_cuda = False
 
     dist = torch_struct.AlignmentCRF(log_potentials)
     assert (N, M, 3) == dist.argmax[0].shape
-    if on_cuda:
+    if torch.cuda.is_available():
         assert (N, M, 3) == dist.marginals[0].shape

--- a/tests/test_alignment_crf.py
+++ b/tests/test_alignment_crf.py
@@ -5,7 +5,7 @@ import warnings
 
 def test_alignment_crf():
     batch, N, M = 1, 4, 5
-    log_potentials = torch.rand(batch, N, M, 3).cuda()
+    log_potentials = torch.rand(batch, N, M, 3)
 
     if torch.cuda.is_available():
         log_potentials = log_potentials.cuda()

--- a/tests/test_alignment_crf.py
+++ b/tests/test_alignment_crf.py
@@ -16,9 +16,9 @@ def test_alignment_crf_shapes():
     # Fail due to AttributeError: 'BandedMatrix' object has no attribute
     # 'unsqueeze'
     assert (batch,) == dist.entropy.shape
-    assert (9, batch, N, M, 3) == dist.sample([9]).shape
+    # assert (9, batch, N, M, 3) == dist.sample([9]).shape
 
     # Fails due to: RuntimeError: Expected condition, x and y to be on
     # the same device, but condition is on cpu and x and y are on
     # cuda:0 and cuda:0 respectively
-    assert (8, batch,) == dist.topk(8).shape
+    # assert (8, batch,) == dist.topk(8).shape

--- a/tests/test_alignment_crf.py
+++ b/tests/test_alignment_crf.py
@@ -1,0 +1,22 @@
+import torch
+import torch_struct
+import warnings
+
+
+def test_alignment_crf():
+    batch, N, M = 1, 4, 5
+    log_potentials = torch.rand(batch, N, M, 3).cuda()
+
+    try:
+        log_potentials = log_potentials.cuda()
+        on_cuda = True
+
+    except Exception:
+        warnings.warn('Could not move log potentials to CUDA device. '
+                      'Will not test marginals.')
+        on_cuda = False
+
+    dist = torch_struct.AlignmentCRF(log_potentials)
+    assert (N, M, 3) == dist.argmax[0].shape
+    if on_cuda:
+        assert (N, M, 3) == dist.marginals[0].shape

--- a/tests/test_alignment_crf.py
+++ b/tests/test_alignment_crf.py
@@ -1,30 +1,25 @@
 import torch
 import torch_struct
 import warnings
+import pytest
 
 
+@pytest.skipif(not torch.cuda.isavailable(), 'needs CUDA')
 def test_alignment_crf_shapes():
     batch, N, M = 2, 4, 5
-    log_potentials = torch.rand(batch, N, M, 3)
-
-    if torch.cuda.is_available():
-        log_potentials = log_potentials.cuda()
-    else:
-        warnings.warn('Could not move log potentials to CUDA device. '
-                      'Will not test marginals.')
+    log_potentials = torch.rand(batch, N, M, 3).cuda()
 
     dist = torch_struct.AlignmentCRF(log_potentials)
     assert (batch, N, M, 3) == dist.argmax.shape
-    if torch.cuda.is_available():
-        assert (batch, N, M, 3) == dist.marginals.shape
-        assert (batch,) == dist.partition.shape
+    assert (batch, N, M, 3) == dist.marginals.shape
+    assert (batch,) == dist.partition.shape
 
-        # Fail due to AttributeError: 'BandedMatrix' object has no attribute
-        # 'unsqueeze'
-        # assert (batch,) == dist.entropy.shape
-        # assert (9, batch, N, M, 3) == dist.sample([9]).shape
+    # Fail due to AttributeError: 'BandedMatrix' object has no attribute
+    # 'unsqueeze'
+    assert (batch,) == dist.entropy.shape
+    assert (9, batch, N, M, 3) == dist.sample([9]).shape
 
-        # Fails due to: RuntimeError: Expected condition, x and y to be on
-        # the same device, but condition is on cpu and x and y are on
-        # cuda:0 and cuda:0 respectively
-        # assert (8, batch,) == dist.topk(8).shape
+    # Fails due to: RuntimeError: Expected condition, x and y to be on
+    # the same device, but condition is on cpu and x and y are on
+    # cuda:0 and cuda:0 respectively
+    assert (8, batch,) == dist.topk(8).shape

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -1,0 +1,14 @@
+import torch
+from hypothesis import given
+from hypothesis.strategies import integers
+import genbmm
+
+bint = integers(min_value=1, max_value=4)
+mint = integers(min_value=6, max_value=8)
+nint = integers(min_value=3, max_value=5)
+kint = integers(min_value=9, max_value=11)
+
+
+@given(bint, mint, nint, kint)
+def test_matmul(batch, m, n, k):
+    a, b = torch.rand((m, n)), torch.rand((n, k))

--- a/tests/test_semirings.py
+++ b/tests/test_semirings.py
@@ -1,5 +1,5 @@
 import torch
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import integers
 
 
@@ -17,6 +17,7 @@ lint = integers(min_value=2, max_value=10)
 
 
 @given(lint, lint, lint)
+@settings(deadline=None)  # Avoid spurious warnings when first run
 def test_max(a, b, c):
     torch.manual_seed(0)
     t1 = torch.rand(a, 1, c).requires_grad_(True)

--- a/torch_struct/alignment.py
+++ b/torch_struct/alignment.py
@@ -1,11 +1,14 @@
 import torch
 from .helpers import _Struct
 import math
+import warnings
 
 try:
     import genbmm
+
 except ImportError:
-    pass
+    warnings.warn('Could not import genbmm. '
+                  'However, genbmm is only used for CUDA operations.')
 
 from .semirings import LogSemiring
 from .semirings.fast_semirings import broadcast
@@ -97,9 +100,7 @@ class Alignment(_Struct):
             # Create finalizing paths.
             point = (l + M) // 2
 
-            charta[1][:, b, point:, 1, ind, :, :, Mid] = semiring.one_(
-                charta[1][:, b, point:, 1, ind, :, :, Mid]
-            )
+            charta[1][:, b, point:, 1, ind, :, :, Mid] = charta[1][:, b, point:, 1, ind, :, :, Mid].fill_(0)
 
         for b in range(lengths.shape[0]):
             point = (lengths[b] + M) // 2

--- a/torch_struct/alignment.py
+++ b/torch_struct/alignment.py
@@ -100,7 +100,9 @@ class Alignment(_Struct):
             # Create finalizing paths.
             point = (l + M) // 2
 
-            charta[1][:, b, point:, 1, ind, :, :, Mid] = charta[1][:, b, point:, 1, ind, :, :, Mid].fill_(0)
+            init = torch.zeros(charta[1].shape, device=charta[1].device).bool()
+            init[:, b, point:, 1, ind, :, :, Mid].fill_(True)
+            charta[1] = semiring.fill(charta[1], init, semiring.one)
 
         for b in range(lengths.shape[0]):
             point = (lengths[b] + M) // 2

--- a/torch_struct/semirings/sample.py
+++ b/torch_struct/semirings/sample.py
@@ -167,6 +167,9 @@ class _MultiSampledLogSumExp(torch.autograd.Function):
     def backward(ctx, grad_output):
 
         logits, part, dim = ctx.saved_tensors
+        # Replace infinite logits with max float, otherwise softmax gives NaNs
+        # Perhaps this could be done earlier (during forward pass)?
+        logits[logits == float('inf')] = torch.finfo(logits.dtype).max
         grad_input = None
         if ctx.needs_input_grad[0]:
 

--- a/torch_struct/semirings/semirings.py
+++ b/torch_struct/semirings/semirings.py
@@ -98,13 +98,6 @@ class _BaseLog(Semiring):
     zero = torch.tensor(-1e5)
     one = torch.tensor(-0.0)
 
-    @classmethod
-    def matmul(cls, a, b):
-        if has_genbmm and isinstance(a, genbmm.BandedMatrix):
-            return b.multiply_log(a.transpose())
-        else:
-            return Semiring.matmul(a, b)
-
     @staticmethod
     def sum(xs, dim=-1):
         return torch.logsumexp(xs, dim=dim)
@@ -147,7 +140,12 @@ class LogSemiring(_BaseLog):
 
     Gradients give marginals.
     """
-    pass
+    @classmethod
+    def matmul(cls, a, b):
+        if has_genbmm and isinstance(a, genbmm.BandedMatrix):
+            return b.multiply_log(a.transpose())
+        else:
+            return _BaseLog.matmul(a, b)
 
 
 class MaxSemiring(_BaseLog):
@@ -393,13 +391,6 @@ class EntropySemiring(Semiring):
         log_sm = xs[0] - part.unsqueeze(d)
         sm = log_sm.exp()
         return torch.stack((part, torch.sum(xs[1].mul(sm) - log_sm.mul(sm), dim=d)))
-
-    @classmethod
-    def matmul(cls, a, b):
-        if has_genbmm and isinstance(a, genbmm.BandedMatrix):
-            return b.multiply(a.transpose())
-        else:
-            return Semiring.matmul(a, b)
 
     @staticmethod
     def mul(a, b):


### PR DESCRIPTION
PR following up discussion [here](https://github.com/harvardnlp/pytorch-struct/issues/106).

For the tests to pass I also had to update `genbmm`. See PR [here](https://github.com/harvardnlp/genbmm/pull/9).

Note that the tests only check the shape of the `argmax` and `marginals`. The values are not checked.