### PR TITLE
Lengths for semimarkov "to_parts" method

### DIFF
--- a/torch_struct/semimarkov.py
+++ b/torch_struct/semimarkov.py
@@ -137,12 +137,15 @@ class SemiMarkov(_Struct):
         labels = torch.zeros(batch, N - 1, K, C, C).long()
         if lengths is None:
             lengths = torch.LongTensor([N] * batch)
+        else:
+            assert max(lengths) == N
+            assert len(lengths) == batch
 
-        for b in range(batch):
+        for b, l in enumerate(lengths):
             last = None
             c = None
             for n in range(0, N):
-                if sequence[b, n] == -1:
+                if sequence[b, n] == -1 or n > l - 1:
                     assert n != 0
                     continue
                 else:


### PR DESCRIPTION
With this modification, the "to_parts" method gives a proper representation of the edges even if the padding tokens are not -1.